### PR TITLE
Add support for postgresql v12-15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
-FROM alpine:3.11
+FROM alpine:3.18
+ARG DEFAULT_PG_VERSION=12
+ARG INFLUXDB_VERSION=1.11.7
+ARG INFLUXDB_SHA256="00c85ff0abbfbc165663ac5feae7e4e36b6d13c9c003e7a400edd013b356da08"
 
 RUN apk add --no-cache ca-certificates
 RUN apk add --no-cache --virtual .build-deps curl && curl https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/bin/mc && chmod +x /usr/bin/mc && apk del .build-deps
-RUN apk add --no-cache postgresql-client mysql-client bash tar influxdb curl jq
+RUN apk add --no-cache \
+  postgresql12-client \
+  postgresql13-client \
+  postgresql14-client \
+  postgresql15-client
+RUN pg_versions set-default ${DEFAULT_PG_VERSION}
+RUN apk add --no-cache mysql-client bash tar curl jq
+WORKDIR /tmp
+RUN curl -SsfL https://download.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}-linux-amd64.tar.gz -o influxdb.tar.gz \
+  && test "$(sha256sum influxdb.tar.gz | awk 'NR==1{print $1}')" = "${INFLUXDB_SHA256}" \
+  && tar -xf influxdb.tar.gz \
+  && mkdir -p /etc/influxdb \
+  && mv influxdb.conf /etc/influxdb \
+  && mv influx* /usr/local/bin \
+  && rm -f influxdb.tar.gz
+ENV INFLUXDB_CONFIG_PATH="/etc/influxdb/influxdb.conf"
+WORKDIR /
 ADD s3_to_s3.sh /usr/bin/s3_to_s3.sh
 RUN chmod +x /usr/bin/s3_to_s3.sh
-
-ENTRYPOINT ["/bin/bash"]
+ADD entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ This is the `minio/mc` image with some additional database clients, which we nee
   - vice versa for `REMOTE`
   - `REMOTE_PREFIX` - Prefix for the remote backups bucket names.
 - This will e.g. copy from `local/bucket` to `remote/prefix-bucket-s3-backup`
+
+## Postgresql backup
+
+For running postgresql backup, the used postgresql client version must match the server version. This image currently contains postgresql clients 12-15 (default=12).
+
+To change the postgresql client version, set the environment variable `DEFAULT_PG_VERSION` accordingly when running this image.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if test -n "${DEFAULT_PG_VERSION}"; then
+  pg_versions set-default "${DEFAULT_PG_VERSION}"
+fi
+
+if [ -z "$1" ]; then
+  exec /bin/bash
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Upgrade to alpine 3.18, supporting newer postgresql versions. Since we set the default postgresql version to 12, this should be a non-breaking change.